### PR TITLE
[Paper] Add function to calculate metrics from posteriors

### DIFF
--- a/sktree/stats/utils.py
+++ b/sktree/stats/utils.py
@@ -95,7 +95,6 @@ METRIC_FUNCTIONS = {
     "mi": _mutual_information,
     "cond_entropy": _cond_entropy,
     "sas98": _SAS98,
-    "pvalues": _pvalues,
 }
 
 POSTERIOR_FUNCTIONS = ("mi", "auc", "cond_entropy")

--- a/sktree/stats/utils.py
+++ b/sktree/stats/utils.py
@@ -81,8 +81,12 @@ def _SAS98(y_true: ArrayLike, y_pred_proba: ArrayLike, max_fpr=0.02) -> float:
     float :
         The estimated SAS98.
     """
-
-    fpr, tpr, thresholds = roc_curve(y_true, y_pred_proba)
+    if y_true.squeeze().ndim != 1:
+        raise ValueError(f"y_true must be 1d, not {y_true.shape}")
+    if 0 in y_true or -1 in y_true :
+        fpr, tpr, thresholds = roc_curve(y_true, y_pred_proba[:,1], pos_label=1,drop_intermediate = False)
+    else:
+        fpr, tpr, thresholds = roc_curve(y_true, y_pred_proba[:,1], pos_label=2,drop_intermediate = False)
     s98 = max([tpr for (fpr, tpr) in zip(fpr, tpr) if fpr <= max_fpr])
     return s98
 

--- a/sktree/tests/test_utils.py
+++ b/sktree/tests/test_utils.py
@@ -1,0 +1,71 @@
+import numpy as np
+import pytest
+from sklearn import datasets
+
+from sklearn.ensemble import RandomForestClassifier
+
+from ..stats.utils import _SAS98, compute_posterior_metrics
+
+# set the constant seed for reproducibility
+SEED = 123
+np.random.seed(SEED)
+# generate toy samples of posteriors, targets
+n_samples = 100
+posteriors = np.random.randn(n_samples, 3)
+n_samples = 100
+posteriors = np.random.uniform(0, 1, size=n_samples)
+y_true = np.array([posteriors >= 0.5]).astype(int).ravel()
+
+_SAS98(posteriors, y_true)
+
+
+def test_sas98():
+    # test that the function returns 0
+    # when all posteriors are 0.5
+    y_true = [1, 1, 0, 0]
+    y_pred_proba = np.repeat(0.5, 4)
+    t = _SAS98(y_true, y_pred_proba, max_fpr=0.02)
+    assert t == 0
+    # test that the function returns 1
+    # when all posteriors are correct
+    y_pred_proba = [0.9, 0.9, 0.1, 0.1]
+    t = _SAS98(y_true, y_pred_proba, max_fpr=0.02)
+    assert t == 1
+
+
+def test_compute_posterior_metrics():
+    # generate toy samples of posteriors, targets
+    n_estimators = 10
+    n_samples = 100
+    N = n_samples + 100
+    n_class = 1
+    posteriors = np.random.uniform(0, 1, size=(n_estimators, N, n_class))
+    # posteriors = np.random.uniform(0, 1, size=n_samples).reshape((1, n_samples,1))
+    test_idx = list(range(n_samples))
+    y_true = (
+        np.random.binomial(1, posteriors[0, test_idx], size=(n_samples, n_class))
+        .astype(int)
+        .ravel()
+    )
+    # test that the function returns 0
+    # when all posteriors are 0.5
+    y_true = [1, 1, 0, 0]
+    y_pred_proba = np.repeat(0.5, 4)
+    t = compute_posterior_metrics(y_true, y_pred_proba, test_idx, metric="auc", max_fpr=0.1)
+    assert t == 0
+    # test that the function returns 1
+    # when all posteriors are correct
+    y_pred_proba = [0.9, 0.9, 0.1, 0.1]
+    t = compute_posterior_metrics(y_true, y_pred_proba, test_idx, metric="auc", max_fpr=0.1)
+    assert t == 1
+    # test that the function returns 0
+    # when all posteriors are 0.5
+    y_true = [1, 1, 0, 0]
+    y_pred_proba = np.repeat(0.5, 4)
+    t = compute_posterior_metrics(y_true, y_pred_proba, test_idx, metric="sas98", max_fpr=0.02)
+    assert t == 0
+    # test that the function returns 1
+    # when all posteriors are correct
+    y_pred_proba = [0.9, 0.9, 0.1, 0.1]
+    t = compute_posterior_metrics(y_true, y_pred_proba, test_idx, metric="sas98", max_fpr=0.02)
+    assert t == 1


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
Add function to calculate metrics from posteriors from saved runs in order to avoid re-running the entire code for different metrics. 

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
-

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [ ] I've read and followed all steps in the [Making a pull request](https://github.com/py-why/pywhy-graphs/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [ ] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/py-why/pywhy-graphs/blob/main/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.

## After submitting

<!-- Please complete this checklist AFTER submitting your PR to speed along the review process. -->
- [ ] All GitHub Actions jobs for my pull request have passed.
