### PR TITLE
[ENH, FIX] Allow scaling_factor in trunk_mixture_classification to be specified

### DIFF
--- a/sktree/datasets/hyppo.py
+++ b/sktree/datasets/hyppo.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import numpy as np
 from scipy.integrate import nquad
 from scipy.stats import entropy, multivariate_normal
@@ -236,6 +238,7 @@ def make_trunk_mixture_classification(
     band_type: str = "ma",
     return_params: bool = False,
     mix: float = 0.5,
+    scaling_factor: Optional[float] = None,
     seed=None,
 ):
     """Generate trunk mixture binary classification dataset.
@@ -281,6 +284,9 @@ def make_trunk_mixture_classification(
     mix : int, optional
         The probabilities associated with the mixture of Gaussians in the ``trunk-mix`` simulation.
         By default 0.5.
+    scaling_factor : float, optional
+        The scaling factor for the covariance matrix. By default None, which
+        defaults to (2/3)**2.
     seed : int, optional
         Random seed, by default None.
 
@@ -355,7 +361,9 @@ def make_trunk_mixture_classification(
 
     # When variance is 1, trunk-mix does not look bimodal at low dimensions.
     # It is set it to (2/3)**2 since that is consistent with Marron and Wand bimodal
-    norm_params = [[mu_0_vec, cov * (2 / 3) ** 2], [mu_1_vec, cov * (2 / 3) ** 2]]
+    if scaling_factor is None:
+        scaling_factor = (2 / 3) ** 2
+    norm_params = [[mu_0_vec, cov * scaling_factor], [mu_1_vec, cov * scaling_factor]]
     X_mixture = np.fromiter(
         (rng.multivariate_normal(*(norm_params[i]), size=1, method=method) for i in mixture_idx),
         dtype=np.dtype((float, n_informative)),
@@ -364,7 +372,7 @@ def make_trunk_mixture_classification(
     X = np.vstack(
         (
             rng.multivariate_normal(
-                np.zeros(n_informative), cov * (2 / 3) ** 2, n_samples // 2, method=method
+                np.zeros(n_informative), cov * scaling_factor, n_samples // 2, method=method
             ),
             X_mixture.reshape(n_samples // 2, n_informative),
         )

--- a/sktree/datasets/tests/test_hyppo.py
+++ b/sktree/datasets/tests/test_hyppo.py
@@ -64,7 +64,7 @@ def test_make_trunk_classification_autoregressive_cov(trunk_gen):
         assert_array_equal(cov_list[0][0, :], [rho**idx for idx in range(n_dim)])
     elif trunk_gen == make_trunk_mixture_classification:
         assert len(data) == 5
-        assert_array_equal(cov_list[0][0, :], [rho**idx * (2.0 / 3) ** 2 for idx in range(n_dim)])
+        assert_array_equal(cov_list[0][0, :], [rho**idx for idx in range(n_dim)])
     assert_array_equal(cov_list[0], cov_list[1])
     assert cov_list[0].shape == (n_dim, n_dim)
 

--- a/sktree/ensemble/_extensions.py
+++ b/sktree/ensemble/_extensions.py
@@ -106,7 +106,7 @@ class ForestClassifierMixin:
 
         Returns
         -------
-        proba_per_tree : array-like of shape (n_samples, n_estimators, n_classes)
+        proba_per_tree : array-like of shape (n_estimators, n_samples, n_classes)
             The probability estimates for each tree in the forest.
         """
         # now evaluate

--- a/sktree/stats/forestht.py
+++ b/sktree/stats/forestht.py
@@ -1465,7 +1465,7 @@ def build_permutation_forest(
         return forest_result
 
 
-def build_hyppo_oob_forest(est, X, y, verbose=False, **est_kwargs):
+def build_hyppo_oob_forest(est: ForestClassifier, X, y, verbose=False, **est_kwargs):
     """Build a hypothesis testing forest using oob samples.
 
     Parameters


### PR DESCRIPTION

Changes proposed in this pull request:
- The covariance should be able to be specified, such that it is the identity matrix in trunk mixture.

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [ ] I've read and followed all steps in the [Making a pull request](https://github.com/py-why/pywhy-graphs/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [ ] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/py-why/pywhy-graphs/blob/main/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.

## After submitting

<!-- Please complete this checklist AFTER submitting your PR to speed along the review process. -->
- [ ] All GitHub Actions jobs for my pull request have passed.
