### PR TITLE
ENH Cleanup multiview API and enable oblique multiview

### DIFF
--- a/doc/whats_new/v0.8.rst
+++ b/doc/whats_new/v0.8.rst
@@ -13,6 +13,12 @@ Version 0.8
 Changelog
 ---------
 
+- |API| :class:`sktree.tree.MultiViewDecisionTreeClassifier` do not have the
+    ``apply_max_features_per_feature_set`` argument anymore. Instead, the
+    ``max_features`` argument is used to control the number of features to
+    consider when looking for the best split within each feature set explicitly.
+    By `Adam Li`_ :pr:`#247`.
+
 Code and Documentation Contributors
 -----------------------------------
 

--- a/examples/hypothesis_testing/plot_MI_imbalanced_hyppo_testing.py
+++ b/examples/hypothesis_testing/plot_MI_imbalanced_hyppo_testing.py
@@ -130,7 +130,6 @@ est = FeatureImportanceForestClassifier(
         max_features=max_features,
         tree_estimator=MultiViewDecisionTreeClassifier(
             feature_set_ends=n_features_views,
-            apply_max_features_per_feature_set=True,
         ),
         random_state=seed,
         honest_fraction=0.5,

--- a/examples/hypothesis_testing/plot_co_MIGHT_alternative.py
+++ b/examples/hypothesis_testing/plot_co_MIGHT_alternative.py
@@ -112,7 +112,6 @@ est = FeatureImportanceForestClassifier(
         max_features=max_features,
         tree_estimator=MultiViewDecisionTreeClassifier(
             feature_set_ends=n_features_ends,
-            apply_max_features_per_feature_set=True,
         ),
         random_state=seed,
         honest_fraction=0.5,

--- a/examples/hypothesis_testing/plot_co_MIGHT_null.py
+++ b/examples/hypothesis_testing/plot_co_MIGHT_null.py
@@ -84,7 +84,6 @@ est = FeatureImportanceForestClassifier(
         max_features=max_features,
         tree_estimator=MultiViewDecisionTreeClassifier(
             feature_set_ends=n_features_ends,
-            apply_max_features_per_feature_set=True,
         ),
         random_state=seed,
         honest_fraction=0.5,
@@ -203,7 +202,6 @@ est = FeatureImportanceForestClassifier(
         max_features=max_features,
         tree_estimator=MultiViewDecisionTreeClassifier(
             feature_set_ends=n_features_ends,
-            apply_max_features_per_feature_set=True,
         ),
         random_state=seed,
         honest_fraction=0.5,

--- a/examples/splitters/plot_multiview_axis_aligned_splitter.py
+++ b/examples/splitters/plot_multiview_axis_aligned_splitter.py
@@ -127,9 +127,6 @@ plt.show()
 # more than the second feature set, we can specify ``max_features_per_set`` as follows:
 # ``max_features_per_set = [3, 1]``. This will sample from the first feature set three times
 # and the second feature set once.
-#
-# .. note:: In practice, this is controlled by the ``apply_max_features_per_feature_set`` parameter
-#   in :class:`sktree.tree.MultiViewDecisionTreeClassifier`.
 
 max_features_per_set_ = np.array([1, 2, 3], dtype=int)
 max_features = np.sum(max_features_per_set_)

--- a/sktree/ensemble/_multiview.py
+++ b/sktree/ensemble/_multiview.py
@@ -159,16 +159,6 @@ class MultiViewRandomForestClassifier(
         - If float, then draw `max_samples * X.shape[0]` samples. Thus,
           `max_samples` should be in the interval `(0.0, 1.0]`.
 
-    feature_combinations : float, default=None
-        The number of features to combine on average at each split
-        of the decision trees. If ``None``, then will default to the minimum of
-        ``(1.5, n_features)``. This controls the number of non-zeros is the
-        projection matrix. Setting the value to 1.0 is equivalent to a
-        traditional decision-tree. ``feature_combinations * max_features``
-        gives the number of expected non-zeros in the projection matrix of shape
-        ``(max_features, n_features)``. Thus this value must always be less than
-        ``n_features`` in order to be valid.
-
     feature_set_ends : array-like of int of shape (n_feature_sets,), default=None
         The indices of the end of each feature set. For example, if the first
         feature set is the first 10 features, and the second feature set is the
@@ -270,7 +260,6 @@ class MultiViewRandomForestClassifier(
         warm_start=False,
         class_weight=None,
         max_samples=None,
-        feature_combinations=None,
         feature_set_ends=None,
         apply_max_features_per_feature_set=False,
     ):
@@ -287,7 +276,6 @@ class MultiViewRandomForestClassifier(
                 "max_leaf_nodes",
                 "min_impurity_decrease",
                 "random_state",
-                "feature_combinations",
                 "feature_set_ends",
                 "apply_max_features_per_feature_set",
             ),
@@ -305,7 +293,6 @@ class MultiViewRandomForestClassifier(
         self.min_samples_split = min_samples_split
         self.min_samples_leaf = min_samples_leaf
         self.max_features = max_features
-        self.feature_combinations = feature_combinations
         self.feature_set_ends = feature_set_ends
         self.apply_max_features_per_feature_set = apply_max_features_per_feature_set
 

--- a/sktree/ensemble/_multiview.py
+++ b/sktree/ensemble/_multiview.py
@@ -165,11 +165,6 @@ class MultiViewRandomForestClassifier(
         next 20 features, then ``feature_set_ends = [10, 30]``. If ``None``,
         then this will assume that there is only one feature set.
 
-    apply_max_features_per_feature_set : bool, default=False
-        Whether to apply sampling per feature set, where ``max_features`` is applied
-        to each feature-set. If ``False``, then sampling
-        is applied over the entire feature space.
-
     Attributes
     ----------
     estimators_ : list of sktree.tree.ObliqueDecisionTreeClassifier
@@ -261,7 +256,6 @@ class MultiViewRandomForestClassifier(
         class_weight=None,
         max_samples=None,
         feature_set_ends=None,
-        apply_max_features_per_feature_set=False,
     ):
         super().__init__(
             estimator=MultiViewDecisionTreeClassifier(),
@@ -277,7 +271,6 @@ class MultiViewRandomForestClassifier(
                 "min_impurity_decrease",
                 "random_state",
                 "feature_set_ends",
-                "apply_max_features_per_feature_set",
             ),
             bootstrap=bootstrap,
             oob_score=oob_score,
@@ -294,7 +287,6 @@ class MultiViewRandomForestClassifier(
         self.min_samples_leaf = min_samples_leaf
         self.max_features = max_features
         self.feature_set_ends = feature_set_ends
-        self.apply_max_features_per_feature_set = apply_max_features_per_feature_set
 
         # unused by oblique forests
         self.min_weight_fraction_leaf = min_weight_fraction_leaf

--- a/sktree/stats/tests/test_forestht.py
+++ b/sktree/stats/tests/test_forestht.py
@@ -710,7 +710,6 @@ def test_comight_repeated_feature_sets():
             tree_estimator=MultiViewDecisionTreeClassifier(
                 feature_set_ends=feature_set_ends,
                 max_features=0.3,
-                apply_max_features_per_feature_set=True,
             ),
         ),
         test_size=0.2,

--- a/sktree/tests/test_multiview_forest.py
+++ b/sktree/tests/test_multiview_forest.py
@@ -150,7 +150,6 @@ def test_three_view_dataset(n_views, max_features):
     clf = MultiViewRandomForestClassifier(
         random_state=seed,
         feature_set_ends=feature_set_ends,
-        apply_max_features_per_feature_set=True,
         max_features=max_features,
         n_estimators=n_estimators,
     )

--- a/sktree/tree/__init__.py
+++ b/sktree/tree/__init__.py
@@ -15,7 +15,7 @@ from ._classes import (
     UnsupervisedObliqueDecisionTree,
 )
 from ._honest_tree import HonestTreeClassifier
-from ._multiview import MultiViewDecisionTreeClassifier
+from ._multiview import MultiViewDecisionTreeClassifier, MultiViewObliqueDecisionTreeClassifier
 from ._neighbors import compute_forest_similarity_matrix
 
 __all__ = [
@@ -34,4 +34,5 @@ __all__ = [
     "ExtraTreeClassifier",
     "ExtraTreeRegressor",
     "MultiViewDecisionTreeClassifier",
+    "MultiViewObliqueDecisionTreeClassifier",
 ]

--- a/sktree/tree/_multiview.py
+++ b/sktree/tree/_multiview.py
@@ -35,6 +35,10 @@ DENSE_SPLITTERS = {
     "best": _oblique_splitter.MultiViewSplitter,
 }
 
+OBLIQUE_DENSE_SPLITTERS = {
+    "best": _oblique_splitter.MultiViewObliqueSplitter,
+}
+
 
 class MultiViewDecisionTreeClassifier(SimMatrixMixin, DecisionTreeClassifier):
     """A multi-view axis-aligned decision tree classifier.
@@ -546,4 +550,468 @@ class MultiViewDecisionTreeClassifier(SimMatrixMixin, DecisionTreeClassifier):
             "n_feature_sets_",
             "n_features_in_set_",
             "max_features_per_set_",
+        ]
+
+
+class MultiViewObliqueDecisionTreeClassifier(SimMatrixMixin, DecisionTreeClassifier):
+    """A multi-view OBLIQUE decision tree classifier.
+
+    This is an experimental feature that applies an oblique decision tree to
+    multiple feature-sets concatenated across columns in ``X``.
+
+    Parameters
+    ----------
+    criterion : {"gini", "entropy"}, default="gini"
+        The function to measure the quality of a split. Supported criteria are
+        "gini" for the Gini impurity and "entropy" for the information gain.
+
+    splitter : {"best"}, default="best"
+        The strategy used to choose the split at each node.
+
+    max_depth : int, default=None
+        The maximum depth of the tree. If None, then nodes are expanded until
+        all leaves are pure or until all leaves contain less than
+        min_samples_split samples.
+
+    min_samples_split : int or float, default=2
+        The minimum number of samples required to split an internal node:
+
+        - If int, then consider `min_samples_split` as the minimum number.
+        - If float, then `min_samples_split` is a fraction and
+          `ceil(min_samples_split * n_samples)` are the minimum
+          number of samples for each split.
+
+    min_samples_leaf : int or float, default=1
+        The minimum number of samples required to be at a leaf node.
+        A split point at any depth will only be considered if it leaves at
+        least ``min_samples_leaf`` training samples in each of the left and
+        right branches.  This may have the effect of smoothing the model,
+        especially in regression.
+
+        - If int, then consider `min_samples_leaf` as the minimum number.
+        - If float, then `min_samples_leaf` is a fraction and
+          `ceil(min_samples_leaf * n_samples)` are the minimum
+          number of samples for each node.
+
+    min_weight_fraction_leaf : float, default=0.0
+        The minimum weighted fraction of the sum total of weights (of all
+        the input samples) required to be at a leaf node. Samples have
+        equal weight when sample_weight is not provided.
+
+    max_features : array-like, int, float or {"auto", "sqrt", "log2"}, default=None
+        The number of features to consider when looking for the best split:
+
+            - If int, then consider `max_features` features at each split.
+            - If float, then `max_features` is a fraction and
+              `int(max_features * n_features)` features are considered at each
+              split.
+            - If "auto", then `max_features=sqrt(n_features)`.
+            - If "sqrt", then `max_features=sqrt(n_features)`.
+            - If "log2", then `max_features=log2(n_features)`.
+            - If None, then `max_features=n_features`.
+
+        If array-like, then `max_features` is the number of features to consider
+        for each feature set following the same logic as above, where
+        ``n_features`` is the number of features in the respective feature set.
+
+        Note: the search for a split does not stop until at least one
+        valid partition of the node samples is found, even if it requires to
+        effectively inspect more than ``max_features`` features.
+
+        Note: Compared to axis-aligned Random Forests, one can set
+        max_features to a number greater then ``n_features``.
+
+    random_state : int, RandomState instance or None, default=None
+        Controls the randomness of the estimator. The features are always
+        randomly permuted at each split, even if ``splitter`` is set to
+        ``"best"``. When ``max_features < n_features``, the algorithm will
+        select ``max_features`` at random at each split before finding the best
+        split among them. But the best found split may vary across different
+        runs, even if ``max_features=n_features``. That is the case, if the
+        improvement of the criterion is identical for several splits and one
+        split has to be selected at random. To obtain a deterministic behaviour
+        during fitting, ``random_state`` has to be fixed to an integer.
+        See :term:`Glossary <random_state>` for details.
+
+    max_leaf_nodes : int, default=None
+        Grow a tree with ``max_leaf_nodes`` in best-first fashion.
+        Best nodes are defined as relative reduction in impurity.
+        If None then unlimited number of leaf nodes.
+
+    min_impurity_decrease : float, default=0.0
+        A node will be split if this split induces a decrease of the impurity
+        greater than or equal to this value.
+
+        The weighted impurity decrease equation is the following::
+
+            N_t / N * (impurity - N_t_R / N_t * right_impurity
+                                - N_t_L / N_t * left_impurity)
+
+        where ``N`` is the total number of samples, ``N_t`` is the number of
+        samples at the current node, ``N_t_L`` is the number of samples in the
+        left child, and ``N_t_R`` is the number of samples in the right child.
+
+        ``N``, ``N_t``, ``N_t_R`` and ``N_t_L`` all refer to the weighted sum,
+        if ``sample_weight`` is passed.
+
+    class_weight : dict, list of dict or "balanced", default=None
+        Weights associated with classes in the form ``{class_label: weight}``.
+        If None, all classes are supposed to have weight one. For
+        multi-output problems, a list of dicts can be provided in the same
+        order as the columns of y.
+
+        Note that for multioutput (including multilabel) weights should be
+        defined for each class of every column in its own dict. For example,
+        for four-class multilabel classification weights should be
+        [{0: 1, 1: 1}, {0: 1, 1: 5}, {0: 1, 1: 1}, {0: 1, 1: 1}] instead of
+        [{1:1}, {2:5}, {3:1}, {4:1}].
+
+        The "balanced" mode uses the values of y to automatically adjust
+        weights inversely proportional to class frequencies in the input data
+        as ``n_samples / (n_classes * np.bincount(y))``
+
+        For multi-output, the weights of each column of y will be multiplied.
+
+        Note that these weights will be multiplied with sample_weight (passed
+        through the fit method) if sample_weight is specified.
+
+    ccp_alpha : non-negative float, default=0.0
+        Not used.
+
+    store_leaf_values : bool, default=False
+        Whether to store the leaf values.
+
+    monotonic_cst : array-like of int of shape (n_features), default=None
+        Indicates the monotonicity constraint to enforce on each feature.
+          - 1: monotonic increase
+          - 0: no constraint
+          - -1: monotonic decrease
+
+        Not used.
+
+    feature_set_ends : array-like of int of shape (n_feature_sets,), default=None
+        The indices of the end of each feature set. For example, if the first
+        feature set is the first 10 features, and the second feature set is the
+        next 20 features, then ``feature_set_ends = [10, 30]``. If ``None``,
+        then this will assume that there is only one feature set.
+
+    Attributes
+    ----------
+    classes_ : ndarray of shape (n_classes,) or list of ndarray
+        The classes labels (single output problem),
+        or a list of arrays of class labels (multi-output problem).
+
+    feature_importances_ : ndarray of shape (n_features,)
+        The impurity-based feature importances.
+        The higher, the more important the feature.
+        The importance of a feature is computed as the (normalized)
+        total reduction of the criterion brought by that feature.  It is also
+        known as the Gini importance [4]_.
+
+        Warning: impurity-based feature importances can be misleading for
+        high cardinality features (many unique values). See
+        :func:`sklearn.inspection.permutation_importance` as an alternative.
+
+    max_features_ : int
+        The inferred value of max_features.
+
+    n_classes_ : int or list of int
+        The number of classes (for single output problems),
+        or a list containing the number of classes for each
+        output (for multi-output problems).
+
+    n_features_in_ : int
+        Number of features seen during :term:`fit`.
+
+    feature_names_in_ : ndarray of shape (`n_features_in_`,)
+        Names of features seen during :term:`fit`. Defined only when `X`
+        has feature names that are all strings.
+
+    n_outputs_ : int
+        The number of outputs when ``fit`` is performed.
+
+    tree_ : Tree instance
+        The underlying Tree object. Please refer to
+        ``help(sklearn.tree._tree.Tree)`` for
+        attributes of Tree object.
+
+    feature_set_ends_ : array-like of int of shape (n_feature_sets,)
+        The indices of the end of each feature set.
+
+    n_feature_sets_ : int
+        The number of feature sets.
+
+    max_features_per_set_ : array-like of int of shape (n_feature_sets,)
+        The number of features to sample per feature set. If ``None``, then
+        ``max_features`` is applied to the entire feature space.
+
+    See Also
+    --------
+    sklearn.tree.DecisionTreeClassifier : An axis-aligned decision tree classifier.
+    """
+
+    tree_type = "oblique"
+
+    _parameter_constraints = {
+        **DecisionTreeClassifier._parameter_constraints,
+        "feature_set_ends": ["array-like", None],
+        "feature_combinations": [
+            Interval(Real, 1.0, None, closed="left"),
+            None,
+        ],
+    }
+    _parameter_constraints.pop("max_features")
+    _parameter_constraints["max_features"] = [
+        Interval(Integral, 1, None, closed="left"),
+        Interval(RealNotInt, 0.0, 1.0, closed="right"),
+        StrOptions({"sqrt", "log2"}),
+        "array-like",
+        None,
+    ]
+
+    def __init__(
+        self,
+        *,
+        criterion="gini",
+        splitter="best",
+        max_depth=None,
+        min_samples_split=2,
+        min_samples_leaf=1,
+        min_weight_fraction_leaf=0.0,
+        max_features=None,
+        random_state=None,
+        max_leaf_nodes=None,
+        min_impurity_decrease=0.0,
+        class_weight=None,
+        ccp_alpha=0.0,
+        store_leaf_values=False,
+        monotonic_cst=None,
+        feature_set_ends=None,
+        feature_combinations=None,
+    ):
+        super().__init__(
+            criterion=criterion,
+            splitter=splitter,
+            max_depth=max_depth,
+            min_samples_split=min_samples_split,
+            min_samples_leaf=min_samples_leaf,
+            min_weight_fraction_leaf=min_weight_fraction_leaf,
+            max_features=max_features,
+            max_leaf_nodes=max_leaf_nodes,
+            class_weight=class_weight,
+            random_state=random_state,
+            min_impurity_decrease=min_impurity_decrease,
+            ccp_alpha=ccp_alpha,
+            store_leaf_values=store_leaf_values,
+            monotonic_cst=monotonic_cst,
+        )
+
+        self.feature_set_ends = feature_set_ends
+        self.feature_combinations = feature_combinations
+        self._max_features_arr = None
+
+    def _build_tree(
+        self,
+        X,
+        y,
+        sample_weight,
+        missing_values_in_feature_mask,
+        min_samples_leaf,
+        min_weight_leaf,
+        max_leaf_nodes,
+        min_samples_split,
+        max_depth,
+        random_state,
+    ):
+        """Build the actual tree.
+
+        Parameters
+        ----------
+        X : {array-like, sparse matrix} of shape (n_samples, n_features)
+            The training input samples. Internally, it will be converted to
+            ``dtype=np.float32`` and if a sparse matrix is provided
+            to a sparse ``csc_matrix``.
+
+        y : array-like of shape (n_samples,) or (n_samples, n_outputs)
+            The target values (class labels) as integers or strings.
+
+        sample_weight : array-like of shape (n_samples,), default=None
+            Sample weights. If None, then samples are equally weighted. Splits
+            that would create child nodes with net zero or negative weight are
+            ignored while searching for a split in each node. Splits are also
+            ignored if they would result in any single class carrying a
+            negative weight in either child node.
+
+        min_samples_leaf : int or float
+            The minimum number of samples required to be at a leaf node.
+
+        min_weight_leaf : float, default=0.0
+           The minimum weighted fraction of the sum total of weights.
+
+        max_leaf_nodes : int, default=None
+            Grow a tree with ``max_leaf_nodes`` in best-first fashion.
+
+        min_samples_split : int or float, default=2
+            The minimum number of samples required to split an internal node.
+
+        max_depth : int, default=None
+            The maximum depth of the tree. If None, then nodes are expanded until
+            all leaves are pure or until all leaves contain less than
+            min_samples_split samples.
+
+        random_state : int, RandomState instance or None, default=None
+            Controls the randomness of the estimator.
+        """
+        monotonic_cst = None
+        _, n_features = X.shape
+
+        self.feature_combinations_ = (
+            self.feature_combinations if self.feature_combinations is not None else 1.5
+        )
+
+        # Build tree
+        criterion = self.criterion
+        if not isinstance(criterion, BaseCriterion):
+            criterion = CRITERIA_CLF[self.criterion](self.n_outputs_, self.n_classes_)
+        else:
+            # Make a deepcopy in case the criterion has mutable attributes that
+            # might be shared and modified concurrently during parallel fitting
+            criterion = copy.deepcopy(criterion)
+
+        if self.feature_set_ends is None:
+            self.feature_set_ends_ = np.asarray([n_features], dtype=np.intp)
+        else:
+            self.feature_set_ends_ = np.atleast_1d(self.feature_set_ends).astype(np.intp)
+        self.n_feature_sets_ = len(self.feature_set_ends_)
+        if self.feature_set_ends_[-1] != n_features:
+            raise ValueError(
+                f"The last feature set end must be equal to the number of features, "
+                f"{n_features}, but got {self.feature_set_ends_[-1]}."
+            )
+
+        splitter = self.splitter
+        if issparse(X):
+            raise ValueError(
+                "Sparse input is not supported for oblique trees. "
+                "Please convert your data to a dense array."
+            )
+
+        if isinstance(self._max_features_arr, (Integral, Real, str, type(None))):
+            max_features_arr_ = [self._max_features_arr] * self.n_feature_sets_
+        else:
+            if not isinstance(self._max_features_arr, (list, np.ndarray)):
+                raise ValueError(
+                    f"max_features must be an array-like, int, float, str, or None; "
+                    f"got {type(self._max_features_arr)}"
+                )
+            if len(self._max_features_arr) != self.n_feature_sets_:
+                raise ValueError(
+                    f"max_features must be an array-like of length {self.n_feature_sets_}; "
+                    f"got {len(self.max_features)}"
+                )
+            max_features_arr_ = self._max_features_arr
+
+        self.n_features_in_set_ = []
+        # XXX: experimental
+        # we can replace max_features_ here based on whether or not uniform logic over
+        # feature sets
+        max_features_per_set = []
+        n_features_in_prev = 0
+        for idx in range(self.n_feature_sets_):
+            max_features = max_features_arr_[idx]
+
+            n_features_in_ = self.feature_set_ends_[idx] - n_features_in_prev
+            n_features_in_prev += n_features_in_
+            self.n_features_in_set_.append(n_features_in_)
+            if isinstance(max_features, str):
+                if max_features == "sqrt":
+                    max_features = max(1, math.ceil(np.sqrt(n_features_in_)))
+                elif max_features == "log2":
+                    max_features = max(1, math.ceil(np.log2(n_features_in_)))
+            elif max_features is None:
+                max_features = n_features_in_
+            elif isinstance(max_features, numbers.Integral):
+                max_features = max_features
+            else:  # float
+                if max_features > 0.0:
+                    max_features = max(1, math.ceil(max_features * n_features_in_))
+                else:
+                    max_features = 0
+
+            if max_features > n_features_in_:
+                raise ValueError(
+                    f"max_features must be less than or equal to "
+                    f"the number of features in feature set {idx}: {n_features_in_}, but "
+                    f"max_features = {max_features} when applying sampling"
+                    f"per feature set."
+                )
+
+            max_features_per_set.append(max_features)
+        self.max_features_ = np.sum(max_features_per_set)
+        if self.max_features_ > n_features:
+            raise ValueError(
+                "max_features is greater than the number of features: "
+                f"{max_features} > {n_features}."
+                "This should not be possible. Please submit a bug report."
+            )
+        self.max_features_per_set_ = np.asarray(max_features_per_set, dtype=np.intp)
+        # the total number of features to sample per split
+        self.max_features_ = np.sum(self.max_features_per_set_)
+
+        if not isinstance(self.splitter, ObliqueSplitter):
+            splitter = OBLIQUE_DENSE_SPLITTERS[self.splitter](
+                criterion,
+                self.max_features_,
+                min_samples_leaf,
+                min_weight_leaf,
+                random_state,
+                monotonic_cst,
+                self.feature_combinations_,
+                self.feature_set_ends_,
+                self.n_feature_sets_,
+                self.max_features_per_set_,
+            )
+
+        self.tree_ = ObliqueTree(self.n_features_in_, self.n_classes_, self.n_outputs_)
+
+        # Use BestFirst if max_leaf_nodes given; use DepthFirst otherwise
+        if max_leaf_nodes < 0:
+            self.builder_ = DepthFirstTreeBuilder(
+                splitter,
+                min_samples_split,
+                min_samples_leaf,
+                min_weight_leaf,
+                max_depth,
+                self.min_impurity_decrease,
+            )
+        else:
+            self.builder_ = BestFirstTreeBuilder(
+                splitter,
+                min_samples_split,
+                min_samples_leaf,
+                min_weight_leaf,
+                max_depth,
+                max_leaf_nodes,
+                self.min_impurity_decrease,
+            )
+
+        self.builder_.build(self.tree_, X, y, sample_weight, None)
+
+        if self.n_outputs_ == 1:
+            self.n_classes_ = self.n_classes_[0]
+            self.classes_ = self.classes_[0]
+
+    @property
+    def _inheritable_fitted_attribute(self):
+        """Define additional attributes to pass onto a parent meta tree-estimator.
+
+        Used for passing parameters to HonestTreeClassifier.
+        """
+        return [
+            "max_features_",
+            "feature_set_ends_",
+            "n_feature_sets_",
+            "n_features_in_set_",
+            "max_features_per_set_",
+            "feature_combinations_",
         ]

--- a/sktree/tree/_multiview.py
+++ b/sktree/tree/_multiview.py
@@ -158,9 +158,6 @@ class MultiViewDecisionTreeClassifier(SimMatrixMixin, DecisionTreeClassifier):
         Note that these weights will be multiplied with sample_weight (passed
         through the fit method) if sample_weight is specified.
 
-    feature_combinations : float, default=None
-        Not used.
-
     ccp_alpha : non-negative float, default=0.0
         Not used.
 
@@ -226,9 +223,6 @@ class MultiViewDecisionTreeClassifier(SimMatrixMixin, DecisionTreeClassifier):
         ``help(sklearn.tree._tree.Tree)`` for
         attributes of Tree object.
 
-    feature_combinations_ : float
-        The number of feature combinations on average taken to fit the tree.
-
     feature_set_ends_ : array-like of int of shape (n_feature_sets,)
         The indices of the end of each feature set.
 
@@ -248,10 +242,6 @@ class MultiViewDecisionTreeClassifier(SimMatrixMixin, DecisionTreeClassifier):
 
     _parameter_constraints = {
         **DecisionTreeClassifier._parameter_constraints,
-        "feature_combinations": [
-            Interval(Real, 1.0, None, closed="left"),
-            None,
-        ],
         "feature_set_ends": ["array-like", None],
         "apply_max_features_per_feature_set": ["boolean"],
     }
@@ -278,7 +268,6 @@ class MultiViewDecisionTreeClassifier(SimMatrixMixin, DecisionTreeClassifier):
         max_leaf_nodes=None,
         min_impurity_decrease=0.0,
         class_weight=None,
-        feature_combinations=None,
         ccp_alpha=0.0,
         store_leaf_values=False,
         monotonic_cst=None,
@@ -302,7 +291,6 @@ class MultiViewDecisionTreeClassifier(SimMatrixMixin, DecisionTreeClassifier):
             monotonic_cst=monotonic_cst,
         )
 
-        self.feature_combinations = feature_combinations
         self.feature_set_ends = feature_set_ends
         self.apply_max_features_per_feature_set = apply_max_features_per_feature_set
         self._max_features_arr = None
@@ -362,7 +350,7 @@ class MultiViewDecisionTreeClassifier(SimMatrixMixin, DecisionTreeClassifier):
         monotonic_cst = None
         _, n_features = X.shape
 
-        self.feature_combinations_ = 1
+        self._feature_combinations_ = 1
 
         # Build tree
         criterion = self.criterion
@@ -485,7 +473,7 @@ class MultiViewDecisionTreeClassifier(SimMatrixMixin, DecisionTreeClassifier):
                 min_weight_leaf,
                 random_state,
                 monotonic_cst,
-                self.feature_combinations_,
+                self._feature_combinations_,
                 self.feature_set_ends_,
                 self.n_feature_sets_,
                 self.max_features_per_set_,
@@ -584,7 +572,6 @@ class MultiViewDecisionTreeClassifier(SimMatrixMixin, DecisionTreeClassifier):
         """
         return [
             "max_features_",
-            "feature_combinations_",
             "feature_set_ends_",
             "n_feature_sets_",
             "n_features_in_set_",

--- a/sktree/tree/_oblique_splitter.pxd
+++ b/sktree/tree/_oblique_splitter.pxd
@@ -164,15 +164,8 @@ cdef class MultiViewSplitter(BestObliqueSplitter):
 
 
 # XXX: This splitter is experimental. Expect changes frequently.
-cdef class MultiViewObliqueSplitter(BestObliqueSplitter):
-    cdef const intp_t[:] feature_set_ends   # an array indicating the column indices of the end of each feature set
-    cdef intp_t n_feature_sets                  # the number of feature sets is the length of feature_set_ends + 1
-
-    # whether or not to uniformly sample feature-sets into each projection vector
-    # if True, then sample from each feature set for each projection vector
-    cdef bint uniform_sampling
-
-    cdef vector[vector[intp_t]] multi_indices_to_sample
+cdef class MultiViewObliqueSplitter(MultiViewSplitter):
+    cdef const intp_t[:] n_non_zeros_per_set  # the number of non-zero features in each feature set
 
     cdef void sample_proj_mat(
         self,

--- a/sktree/tree/_oblique_splitter.pyx
+++ b/sktree/tree/_oblique_splitter.pyx
@@ -789,6 +789,8 @@ cdef class MultiViewSplitter(BestObliqueSplitter):
                     break
 
 
+# TODO: need to check segfault for multiview oblique splitter
+# REBUILD WITH BOUNDS CHECK
 cdef class MultiViewObliqueSplitter(MultiViewSplitter):
     def __cinit__(
         self,

--- a/sktree/tree/tests/test_all_trees.py
+++ b/sktree/tree/tests/test_all_trees.py
@@ -2,13 +2,15 @@ import joblib
 import numpy as np
 import pytest
 from numpy.testing import assert_almost_equal, assert_array_equal
-from sklearn.base import is_classifier
+from sklearn.base import is_classifier, is_regressor
 from sklearn.datasets import make_blobs
 from sklearn.tree._tree import TREE_LEAF
 
 from sktree.tree import (
     ExtraObliqueDecisionTreeClassifier,
     ExtraObliqueDecisionTreeRegressor,
+    MultiViewDecisionTreeClassifier,
+    MultiViewObliqueDecisionTreeClassifier,
     ObliqueDecisionTreeClassifier,
     ObliqueDecisionTreeRegressor,
     PatchObliqueDecisionTreeClassifier,
@@ -26,6 +28,8 @@ ALL_TREES = [
     PatchObliqueDecisionTreeClassifier,
     UnsupervisedDecisionTree,
     UnsupervisedObliqueDecisionTree,
+    MultiViewDecisionTreeClassifier,
+    MultiViewObliqueDecisionTreeClassifier,
 ]
 
 
@@ -121,7 +125,7 @@ y_small_reg = [
 
 @pytest.mark.parametrize(
     "TREE",
-    [ObliqueDecisionTreeClassifier, UnsupervisedDecisionTree, UnsupervisedObliqueDecisionTree],
+    ALL_TREES,
 )
 def test_tree_deserialization_from_read_only_buffer(tmpdir, TREE):
     """Check that Trees can be deserialized with read only buffers.
@@ -131,7 +135,7 @@ def test_tree_deserialization_from_read_only_buffer(tmpdir, TREE):
     pickle_path = str(tmpdir.join("clf.joblib"))
     clf = TREE(random_state=0)
 
-    if is_classifier(TREE):
+    if is_classifier(TREE) or is_regressor(TREE):
         clf.fit(X_small, y_small)
     else:
         clf.fit(X_small)

--- a/sktree/tree/tests/test_multiview.py
+++ b/sktree/tree/tests/test_multiview.py
@@ -102,7 +102,6 @@ def test_multiview_errors():
         random_state=seed,
         feature_set_ends=[3, 5],
         max_features=6,
-        apply_max_features_per_feature_set=True,
     )
     with pytest.raises(ValueError, match="the number of features in feature set"):
         clf.fit(X, y)
@@ -117,7 +116,6 @@ def test_multiview_separate_feature_set_sampling_sets_attributes():
         random_state=seed,
         feature_set_ends=[6, 10],
         max_features=0.5,
-        apply_max_features_per_feature_set=True,
     )
     clf.fit(X, y)
 
@@ -130,7 +128,6 @@ def test_multiview_separate_feature_set_sampling_sets_attributes():
         random_state=seed,
         feature_set_ends=[9, 13],
         max_features="sqrt",
-        apply_max_features_per_feature_set=True,
     )
     clf.fit(X, y)
     assert_array_equal(clf.max_features_per_set_, [3, 2])
@@ -142,7 +139,6 @@ def test_multiview_separate_feature_set_sampling_sets_attributes():
         random_state=seed,
         feature_set_ends=[5, 9],
         max_features="sqrt",
-        apply_max_features_per_feature_set=True,
     )
     clf.fit(X, y)
     assert_array_equal(clf.max_features_per_set_, [3, 2])
@@ -160,7 +156,6 @@ def test_at_least_one_feature_per_view_is_sampled():
         random_state=seed,
         feature_set_ends=[1, 2, 4, 10],
         max_features=0.4,
-        apply_max_features_per_feature_set=True,
     )
     clf.fit(X, y)
 
@@ -178,7 +173,6 @@ def test_multiview_separate_feature_set_sampling_is_consistent():
         random_state=seed,
         feature_set_ends=[1, 3, 6, 10],
         max_features=[1, 2, 2, 3],
-        apply_max_features_per_feature_set=True,
     )
     clf.fit(X, y)
 
@@ -192,15 +186,13 @@ def test_multiview_separate_feature_set_sampling_is_consistent():
         random_state=seed,
         feature_set_ends=[1, 3, 6, 10],
         max_features=[1, 2, 2, 3],
-        apply_max_features_per_feature_set=False,
     )
     other_clf.fit(X, y)
 
     assert_array_equal(other_clf.tree_.value, clf.tree_.value)
 
 
-@pytest.mark.parametrize("stratify_mtry_per_view", [True, False])
-def test_separate_mtry_per_feature_set(stratify_mtry_per_view):
+def test_separate_mtry_per_feature_set():
     """Test that multiview decision tree can sample different numbers of features per view.
 
     Sets the ``max_feature`` argument as an array-like.
@@ -213,7 +205,6 @@ def test_separate_mtry_per_feature_set(stratify_mtry_per_view):
         random_state=seed,
         feature_set_ends=[1, 2, 4, 10],
         max_features=[0.4, 0.5, 0.6, 0.7],
-        apply_max_features_per_feature_set=stratify_mtry_per_view,
     )
     clf.fit(X, y)
 
@@ -225,7 +216,6 @@ def test_separate_mtry_per_feature_set(stratify_mtry_per_view):
         random_state=seed,
         feature_set_ends=[1, 2, 4, 10],
         max_features=[1, 1, 1, 1.0],
-        apply_max_features_per_feature_set=stratify_mtry_per_view,
     )
     clf.fit(X, y)
     assert_array_equal(clf.max_features_per_set_, [1, 1, 1, 6])
@@ -236,14 +226,9 @@ def test_separate_mtry_per_feature_set(stratify_mtry_per_view):
         random_state=seed,
         feature_set_ends=[1, 2, 4, 10],
         max_features=1.0,
-        apply_max_features_per_feature_set=stratify_mtry_per_view,
     )
     clf.fit(X, y)
-    if stratify_mtry_per_view:
-        assert_array_equal(clf.max_features_per_set_, [1, 1, 2, 6])
-    else:
-        assert clf.max_features_per_set_ is None
-        assert clf.max_features_ == 10
+    assert_array_equal(clf.max_features_per_set_, [1, 1, 2, 6])
     assert clf.max_features_ == 10, np.sum(clf.max_features_per_set_)
 
 
@@ -262,9 +247,10 @@ def test_multiview_without_feature_view_stratification():
         random_state=seed,
         feature_set_ends=[497, 500],
         max_features=0.3,
-        apply_max_features_per_feature_set=False,
     )
     clf.fit(X, y)
 
-    assert clf.max_features_per_set_ is None
-    assert clf.max_features_ == 500 * clf.max_features, clf.max_features_
+    assert_array_equal(clf.max_features_per_set_, [150, 1]), clf.max_features_per_set_
+    assert clf.max_features_ == math.ceil(497.0 * clf.max_features) + math.ceil(
+        3 * clf.max_features
+    )


### PR DESCRIPTION
Changes proposed in this pull request:
- Removes unnecessary kwargs in `MultiViewDTC` and Forest
- Enables a Cythonized splitter for sampling oblique multi-view DTC.

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [ ] I've read and followed all steps in the [Making a pull request](https://github.com/py-why/pywhy-graphs/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [ ] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/py-why/pywhy-graphs/blob/main/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.

## After submitting

<!-- Please complete this checklist AFTER submitting your PR to speed along the review process. -->
- [ ] All GitHub Actions jobs for my pull request have passed.
