### PR TITLE
FIX Raise error when missing-values encountered in scikit-tree trees

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,6 +61,7 @@ jobs:
         run: |
           brew install ccache
           brew install gcc
+          brew install gettext
 
       - name: show-gcc
         run: |

--- a/build_requirements.txt
+++ b/build_requirements.txt
@@ -1,9 +1,9 @@
-meson
-meson-python
-cython>=3.0.8
+meson>=1.4.0
+meson-python>=0.16.0
+cython>=3.0.10
 ninja
 numpy
-scikit-learn>=1.4.1
+scikit-learn>=1.4.2
 click
 rich-click
 doit

--- a/doc/whats_new/v0.8.rst
+++ b/doc/whats_new/v0.8.rst
@@ -17,7 +17,7 @@ Changelog
     did not raise an error, and silently ran, assuming the missing-values were
     encoded as infinity value. This is now fixed, and the estimators will raise an
     ValueError if missing-values are encountered in ``X`` input array.
-    By `Adam Li`_ (:pr:`#263`)
+    By `Adam Li`_ (:pr:`#264`)
 
 Code and Documentation Contributors
 -----------------------------------

--- a/doc/whats_new/v0.8.rst
+++ b/doc/whats_new/v0.8.rst
@@ -13,6 +13,12 @@ Version 0.8
 Changelog
 ---------
 
+- |Fix| Previously missing-values in ``X`` input array for sktree estimators
+    did not raise an error, and silently ran, assuming the missing-values were
+    encoded as infinity value. This is now fixed, and the estimators will raise an
+    ValueError if missing-values are encountered in ``X`` input array.
+    By `Adam Li`_ (:pr:`#254`)
+
 Code and Documentation Contributors
 -----------------------------------
 

--- a/doc/whats_new/v0.8.rst
+++ b/doc/whats_new/v0.8.rst
@@ -17,7 +17,7 @@ Changelog
     did not raise an error, and silently ran, assuming the missing-values were
     encoded as infinity value. This is now fixed, and the estimators will raise an
     ValueError if missing-values are encountered in ``X`` input array.
-    By `Adam Li`_ (:pr:`#254`)
+    By `Adam Li`_ (:pr:`#263`)
 
 Code and Documentation Contributors
 -----------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 build-backend = "mesonpy"
 requires = [
-  "meson-python>=0.15.0",
+  "meson-python>=0.16.0",
   'ninja',
   # `wheel` is needed for non-isolated builds, given that `meson-python`
   # doesn't list it as a runtime requirement (at least in 0.10.0)
@@ -9,7 +9,7 @@ requires = [
   "wheel",
   "setuptools<=65.5",
   "packaging",
-  "Cython>=3.0.8",
+  "Cython>=3.0.10",
   "scikit-learn>=1.4.1",
   "scipy>=1.5.0",
   "numpy>=1.25; python_version>='3.9'"

--- a/sktree/tree/_neighbors.py
+++ b/sktree/tree/_neighbors.py
@@ -64,3 +64,7 @@ class SimMatrixMixin:
             The similarity matrix among the samples.
         """
         return compute_forest_similarity_matrix(self, X)
+
+    def _more_tags(self):
+        # XXX: no scikit-tree estimators support NaNs as of now
+        return {"allow_nan": False}

--- a/sktree/tree/tests/test_all_trees.py
+++ b/sktree/tree/tests/test_all_trees.py
@@ -3,7 +3,7 @@ import numpy as np
 import pytest
 from numpy.testing import assert_almost_equal, assert_array_equal
 from sklearn.base import is_classifier
-from sklearn.datasets import make_blobs
+from sklearn.datasets import load_iris, make_blobs
 from sklearn.tree._tree import TREE_LEAF
 
 from sktree.tree import (
@@ -162,3 +162,24 @@ def test_similarity_matrix(tree):
 
     assert np.allclose(sim_mat, sim_mat.T)
     assert np.all((sim_mat.diagonal() == 1))
+
+
+@pytest.mark.parametrize("tree", ALL_TREES)
+def test_missing_values(tree):
+    """Smoke test to ensure that correct error is raised when missing values are present.
+
+    xref: https://github.com/neurodata/scikit-tree/issues/263
+    """
+    rng = np.random.default_rng(123)
+
+    iris_X, iris_y = load_iris(return_X_y=True, as_frame=True)
+
+    # Make the feature matrix 25% sparse
+    iris_X = iris_X.mask(rng.standard_normal(iris_X.shape) < 0.25)
+
+    classifier = tree()
+    with pytest.raises(ValueError, match="Input X contains NaN"):
+        if tree.__name__.startswith("Unsupervised"):
+            classifier.fit(iris_X)
+        else:
+            classifier.fit(iris_X, iris_y)


### PR DESCRIPTION
Fixes #263 

Changes proposed in this pull request:
- raises a ValueError when missing-value encountered in scikit-tree estimators

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [ ] I've read and followed all steps in the [Making a pull request](https://github.com/py-why/pywhy-graphs/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [ ] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/py-why/pywhy-graphs/blob/main/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.

## After submitting

<!-- Please complete this checklist AFTER submitting your PR to speed along the review process. -->
- [ ] All GitHub Actions jobs for my pull request have passed.
