### PR TITLE
dropped bottleneck warning message

### DIFF
--- a/treeple/stats/utils.py
+++ b/treeple/stats/utils.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import warnings
 from typing import Optional, Tuple
 
 import numpy as np

--- a/treeple/stats/utils.py
+++ b/treeple/stats/utils.py
@@ -31,9 +31,6 @@ if BOTTLENECK_AVAILABLE and DISABLE_BN_ENV_VAR not in os.environ:
     nanmean_f = bn.nanmean
     anynan_f = lambda arr: bn.anynan(arr, axis=2)
 else:
-    warnings.warn(
-        "Not using bottleneck for calculations involvings nans. Expect slower performance."
-    )
     nanmean_f = np.nanmean
     anynan_f = lambda arr: np.isnan(arr).any(axis=2)
 


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #310

#### What does this implement/fix? Explain your changes.

Drops a bottleneck warning that appears every import of `treeple.stats`, which can be too much if the user isn't using the functions that depend on bottleneck for nans.

#### Any other comments?

Rather than move the warning, it makes sense to drop it for now. I am working on a  sparse implementation of some of the `treeple.stats` calculations that will involve a refactor and so the warning may have a better home somewhere else when I am done.

