### PR TITLE
Sparse Implementation of `build_coleman_forest` plus a fix for bottleneck import

### DIFF
--- a/doc/whats_new/v0.10.rst
+++ b/doc/whats_new/v0.10.rst
@@ -15,6 +15,8 @@ Changelog
 
 - |Feature| Calculations involving nans in ``treeple.stats.utils`` now use the
     ``bottleneck`` library for faster computation. By `Ryan Hausen`_ (:pr:`#306`)
+- |Feature| Added a sparse implementation of `treeple.stats.forest.build_colemen_forest`
+    that uses the `scipy.sparse` module. By `Ryan Hausen`_ (:pr:`#317`)
 
 
 Code and Documentation Contributors

--- a/treeple/stats/forest.py
+++ b/treeple/stats/forest.py
@@ -12,7 +12,12 @@ from sklearn.utils.multiclass import type_of_target
 from .._lib.sklearn.ensemble._forest import ForestClassifier
 from ..tree._classes import DTYPE
 from .permuteforest import PermutationHonestForestClassifier
-from .utils import METRIC_FUNCTIONS, POSITIVE_METRICS, _compute_null_distribution_coleman
+from .utils import (
+    METRIC_FUNCTIONS,
+    POSITIVE_METRICS,
+    _compute_null_distribution_coleman,
+    _compute_null_distribution_coleman_sparse,
+)
 
 
 def _parallel_predict_proba_oob(predict_proba, X, out, idx, test_idx, lock):
@@ -29,6 +34,20 @@ def _parallel_predict_proba_oob(predict_proba, X, out, idx, test_idx, lock):
     with lock:
         out[idx, test_idx, :] = prediction[test_idx, :]
     return prediction
+
+
+def _parallel_predict_proba_oob_sparse(predict_proba, X, test_idx):
+    """
+    This is a utility function for joblib's Parallel.
+    It can't go locally in ForestClassifier or ForestRegressor, because joblib
+    complains that it cannot pickle it when placed there. Different from
+    _parallel_predict_proba_oob, this function returns the predictions and
+    indices for those values that are finite (not nan or inf).
+    """
+    # each tree predicts proba with a list of output (n_samples, n_classes[i])
+    prediction = predict_proba(X[test_idx, :], check_input=False)
+    good_value_mask = np.isfinite(prediction[:, 0])
+    return test_idx[good_value_mask], prediction[good_value_mask]
 
 
 ForestTestResult = namedtuple(
@@ -48,6 +67,7 @@ def build_coleman_forest(
     verbose=False,
     seed=None,
     return_posteriors=True,
+    use_sparse=False,
     **metric_kwargs,
 ):
     """Build a hypothesis testing forest using a two-forest approach.
@@ -86,6 +106,8 @@ def build_coleman_forest(
         Random seed, by default None.
     return_posteriors : bool, optional
         Whether or not to return the posteriors, by default True.
+    use_sparse : bool, optional
+        Whether or not to use a sparse representation for the posteriors.
     **metric_kwargs : dict, optional
         Additional keyword arguments to pass to the metric function.
 
@@ -112,14 +134,19 @@ def build_coleman_forest(
     metric_func: Callable[[ArrayLike, ArrayLike], float] = METRIC_FUNCTIONS[metric]
 
     # build two sets of forests
-    est, orig_forest_proba = build_oob_forest(est, X, y, verbose=verbose)
+    est, orig_forest_proba = build_oob_forest(est, X, y, use_sparse=use_sparse, verbose=verbose)
 
     if not isinstance(perm_est, PermutationHonestForestClassifier):
         raise RuntimeError(
             f"Permutation forest must be a PermutationHonestForestClassifier, got {type(perm_est)}"
         )
     perm_est, perm_forest_proba = build_oob_forest(
-        perm_est, X, y, verbose=verbose, covariate_index=covariate_index
+        perm_est,
+        X,
+        y,
+        use_sparse=use_sparse,
+        verbose=verbose,
+        covariate_index=covariate_index,
     )
 
     # get the number of jobs
@@ -127,21 +154,46 @@ def build_coleman_forest(
 
     if y.ndim == 1:
         y = y.reshape(-1, 1)
-    metric_star, metric_star_pi = _compute_null_distribution_coleman(
-        y,
-        orig_forest_proba,
-        perm_forest_proba,
-        metric,
-        n_repeats=n_repeats,
-        seed=seed,
-        n_jobs=n_jobs,
-        **metric_kwargs,
-    )
 
-    y_pred_proba_orig = np.nanmean(orig_forest_proba, axis=0)
-    y_pred_proba_perm = np.nanmean(perm_forest_proba, axis=0)
-    observe_stat = metric_func(y, y_pred_proba_orig, **metric_kwargs)
-    permute_stat = metric_func(y, y_pred_proba_perm, **metric_kwargs)
+    if use_sparse:
+        y_pred_proba_orig_perm, observe_stat, permute_stat, metric_star, metric_star_pi = (
+            _compute_null_distribution_coleman_sparse(
+                y,
+                orig_forest_proba,
+                perm_forest_proba,
+                metric,
+                n_repeats=n_repeats,
+                seed=seed,
+                n_jobs=n_jobs,
+                **metric_kwargs,
+            )
+        )
+
+        # if we are returning the posteriors, then we need to replace the
+        # sparse indices and values with an array
+        if return_posteriors:
+            n_trees = y_pred_proba_orig_perm.shape[0] // 2
+            # slicing a csc matrix this way is not efficient, but it is
+            # it is only done once, so I am not sure if it is worth it to
+            # optimize this.
+            orig_forest_proba = y_pred_proba_orig_perm[:n_trees, :]
+            perm_forest_proba = y_pred_proba_orig_perm[n_trees:, :]
+    else:
+        metric_star, metric_star_pi = _compute_null_distribution_coleman(
+            y,
+            orig_forest_proba,
+            perm_forest_proba,
+            metric,
+            n_repeats=n_repeats,
+            seed=seed,
+            n_jobs=n_jobs,
+            **metric_kwargs,
+        )
+
+        y_pred_proba_orig = np.nanmean(orig_forest_proba, axis=0)
+        y_pred_proba_perm = np.nanmean(perm_forest_proba, axis=0)
+        observe_stat = metric_func(y, y_pred_proba_orig, **metric_kwargs)
+        permute_stat = metric_func(y, y_pred_proba_perm, **metric_kwargs)
 
     # metric^\pi - metric = observed test statistic, which under the
     # null is normally distributed around 0
@@ -165,7 +217,9 @@ def build_coleman_forest(
         return forest_result
 
 
-def build_oob_forest(est: ForestClassifier, X, y, verbose=False, **est_kwargs):
+def build_oob_forest(
+    est: ForestClassifier, X, y, use_sparse: bool = False, verbose=False, **est_kwargs
+):
     """Build a hypothesis testing forest using oob samples.
 
     Parameters
@@ -179,6 +233,8 @@ def build_oob_forest(est: ForestClassifier, X, y, verbose=False, **est_kwargs):
         Data.
     y : ArrayLike of shape (n_samples, n_outputs)
         Binary target, so ``n_outputs`` should be at most 1.
+    use_sparse : bool, optional
+        Whether or not to use a sparse representation for the posteriors.
     verbose : bool, optional
         Verbosity, by default False.
     **est_kwargs : dict, optional
@@ -213,26 +269,46 @@ def build_oob_forest(est: ForestClassifier, X, y, verbose=False, **est_kwargs):
     # Assign chunk of trees to jobs
     n_jobs, _, _ = _partition_estimators(est.n_estimators, est.n_jobs)
 
-    # avoid storing the output of every estimator by summing them here
-    lock = threading.Lock()
-    # accumulate the predictions across all trees
-    all_proba = np.full(
-        (len(est.estimators_), X.shape[0], est.n_classes_), np.nan, dtype=np.float64
-    )
-    if hasattr(est, "oob_samples_"):
-        Parallel(n_jobs=n_jobs, verbose=verbose, require="sharedmem")(
-            delayed(_parallel_predict_proba_oob)(e.predict_proba, X, all_proba, idx, test_idx, lock)
-            for idx, (e, test_idx) in enumerate(zip(est.estimators_, est.oob_samples_))
+    if use_sparse:
+        if hasattr(est, "oob_samples_"):
+            oob_samples_list = est.oob_samples_
+        else:
+            inbag_samples = est.estimators_samples_
+            all_samples = np.arange(X.shape[0])
+            oob_samples_list = [
+                np.setdiff1d(all_samples, inbag_samples[i]) for i in range(len(inbag_samples))
+            ]
+
+        oob_preds_test_idxs = Parallel(n_jobs=n_jobs, verbose=verbose, require="sharedmem")(
+            delayed(_parallel_predict_proba_oob_sparse)(e.predict_proba, X, test_idx)
+            for e, test_idx in zip(est.estimators_, oob_samples_list)
         )
+        all_proba = list(zip(*oob_preds_test_idxs))
     else:
-        inbag_samples = est.estimators_samples_
-        all_samples = np.arange(X.shape[0])
-        oob_samples_list = [
-            np.setdiff1d(all_samples, inbag_samples[i]) for i in range(len(inbag_samples))
-        ]
-        Parallel(n_jobs=n_jobs, verbose=verbose, require="sharedmem")(
-            delayed(_parallel_predict_proba_oob)(e.predict_proba, X, all_proba, idx, test_idx, lock)
-            for idx, (e, test_idx) in enumerate(zip(est.estimators_, oob_samples_list))
+        # avoid storing the output of every estimator by summing them here
+        lock = threading.Lock()
+        # accumulate the predictions across all trees
+        all_proba = np.full(
+            (len(est.estimators_), X.shape[0], est.n_classes_), np.nan, dtype=np.float64
         )
+        if hasattr(est, "oob_samples_"):
+            Parallel(n_jobs=n_jobs, verbose=verbose, require="sharedmem")(
+                delayed(_parallel_predict_proba_oob)(
+                    e.predict_proba, X, all_proba, idx, test_idx, lock
+                )
+                for idx, (e, test_idx) in enumerate(zip(est.estimators_, est.oob_samples_))
+            )
+        else:
+            inbag_samples = est.estimators_samples_
+            all_samples = np.arange(X.shape[0])
+            oob_samples_list = [
+                np.setdiff1d(all_samples, inbag_samples[i]) for i in range(len(inbag_samples))
+            ]
+            Parallel(n_jobs=n_jobs, verbose=verbose, require="sharedmem")(
+                delayed(_parallel_predict_proba_oob)(
+                    e.predict_proba, X, all_proba, idx, test_idx, lock
+                )
+                for idx, (e, test_idx) in enumerate(zip(est.estimators_, oob_samples_list))
+            )
 
     return est, all_proba

--- a/treeple/stats/forest.py
+++ b/treeple/stats/forest.py
@@ -171,13 +171,12 @@ def build_coleman_forest(
         )
 
         # if we are returning the posteriors, then we need to replace the
-        # sparse indices and values with an array
+        # sparse indices and values with an array. We convert the sparse data
+        # to dense data, so that the function returns results in a consistent format.
         if return_posteriors:
             n_trees = y_pred_proba_orig_perm.shape[0] // 2
             n_samples = y_pred_proba_orig_perm.shape[1]
-            # slicing a csc matrix this way is not efficient, but it is
-            # it is only done once, so I am not sure if it is worth it to
-            # optimize this.
+
             to_coords_data = lambda x: (x.row.astype(int), x.col.astype(int), x.data)
 
             row, col, data = to_coords_data(y_pred_proba_orig_perm[:n_trees, :].tocoo())

--- a/treeple/stats/tests/test_forest.py
+++ b/treeple/stats/tests/test_forest.py
@@ -238,21 +238,20 @@ def test_comight_repeated_feature_sets(seed):
 
 @pytest.mark.parametrize(
     ("use_bottleneck", "use_sparse"),
-    itertools.product([True, False], [True, False]),
+    itertools.product([False, True], [False, True]),
 )
 def test_build_coleman_forest(use_bottleneck: bool, use_sparse: bool):
     """Simple test for building a Coleman forest.
 
     Test the function under alternative and null hypothesis for a very simple dataset.
     """
-    if use_bottleneck and utils.DISABLE_BN_ENV_VAR in os.environ:
-        del os.environ[utils.DISABLE_BN_ENV_VAR]
-        importlib.reload(utils)
-        importlib.reload(stats)
-    else:
+    if not use_bottleneck and utils.DISABLE_BN_ENV_VAR not in os.environ:
         os.environ[utils.DISABLE_BN_ENV_VAR] = "1"
-        importlib.reload(utils)
-        importlib.reload(stats)
+    elif use_bottleneck and utils.DISABLE_BN_ENV_VAR in os.environ:
+        del os.environ[utils.DISABLE_BN_ENV_VAR]
+
+    importlib.reload(utils)
+    importlib.reload(stats)
 
     n_estimators = 100
     n_samples = 30
@@ -436,3 +435,7 @@ def test_build_oob_random_forest():
         assert len(np.unique(structure_samples[tree_idx])) + len(oob_samples_list[tree_idx]) == len(
             samples
         ), f"{tree_idx} {len(structure_samples[tree_idx])} + {len(oob_samples_list[tree_idx])} != {len(samples)}"
+
+
+if __name__ == "__main__":
+    test_build_coleman_forest(False, False)

--- a/treeple/stats/tests/test_forest.py
+++ b/treeple/stats/tests/test_forest.py
@@ -238,7 +238,7 @@ def test_comight_repeated_feature_sets(seed):
 
 @pytest.mark.parametrize(
     ("use_bottleneck", "use_sparse"),
-    itertools.product([False, True], [False, True]),
+    itertools.product([True, False], [True, False]),
 )
 def test_build_coleman_forest(use_bottleneck: bool, use_sparse: bool):
     """Simple test for building a Coleman forest.

--- a/treeple/stats/tests/test_forest.py
+++ b/treeple/stats/tests/test_forest.py
@@ -435,7 +435,3 @@ def test_build_oob_random_forest():
         assert len(np.unique(structure_samples[tree_idx])) + len(oob_samples_list[tree_idx]) == len(
             samples
         ), f"{tree_idx} {len(structure_samples[tree_idx])} + {len(oob_samples_list[tree_idx])} != {len(samples)}"
-
-
-if __name__ == "__main__":
-    test_build_coleman_forest(False, False)

--- a/treeple/stats/tests/test_forest.py
+++ b/treeple/stats/tests/test_forest.py
@@ -1,4 +1,5 @@
 import importlib
+import itertools
 import os
 
 import numpy as np
@@ -235,8 +236,11 @@ def test_comight_repeated_feature_sets(seed):
     assert result.pvalue > 0.05, f"{result.pvalue}"
 
 
-@pytest.mark.parametrize("use_bottleneck", [True, False])
-def test_build_coleman_forest(use_bottleneck: bool):
+@pytest.mark.parametrize(
+    ("use_bottleneck", "use_sparse"),
+    itertools.product([True, False], [True, False]),
+)
+def test_build_coleman_forest(use_bottleneck: bool, use_sparse: bool):
     """Simple test for building a Coleman forest.
 
     Test the function under alternative and null hypothesis for a very simple dataset.
@@ -290,7 +294,9 @@ def test_build_coleman_forest(use_bottleneck: bool):
         perm_forest_proba,
         clf_fitted,
         perm_clf_fitted,
-    ) = stats.build_coleman_forest(clf, perm_clf, X, y, metric="s@98", n_repeats=1000, seed=seed)
+    ) = stats.build_coleman_forest(
+        clf, perm_clf, X, y, metric="s@98", n_repeats=1000, seed=seed, use_sparse=use_sparse
+    )
     assert clf_fitted._n_samples_bootstrap == round(n_samples * 1.6)
     assert perm_clf_fitted._n_samples_bootstrap == round(n_samples * 1.6)
     assert_array_equal(perm_clf_fitted.permutation_indices_.shape, (n_samples, 1))

--- a/treeple/stats/tests/test_forest.py
+++ b/treeple/stats/tests/test_forest.py
@@ -250,6 +250,8 @@ def test_build_coleman_forest(use_bottleneck: bool, use_sparse: bool):
     elif use_bottleneck and utils.DISABLE_BN_ENV_VAR in os.environ:
         del os.environ[utils.DISABLE_BN_ENV_VAR]
 
+    # We need to reload the modules after changing the environment variable
+    # because an environment variable is used to disable bottleneck
     importlib.reload(utils)
     importlib.reload(stats)
 

--- a/treeple/stats/tests/test_utils.py
+++ b/treeple/stats/tests/test_utils.py
@@ -67,3 +67,24 @@ def test_non_nan_samples(use_bottleneck: bool):
     expected = np.array([0, 2])
     actual = utils._non_nan_samples(posterior_array)
     np.testing.assert_array_equal(expected, actual)
+
+
+@pytest.mark.parametrize("use_bottleneck", [True, False])
+def test_nanmean_f(use_bottleneck: bool):
+    if use_bottleneck and utils.DISABLE_BN_ENV_VAR in os.environ:
+        del os.environ[utils.DISABLE_BN_ENV_VAR]
+        importlib.reload(utils)
+    else:
+        os.environ[utils.DISABLE_BN_ENV_VAR] = "1"
+        importlib.reload(utils)
+
+    posterior_array = np.array(
+        [
+            [1, 2, np.nan],
+            [3, 4, np.nan],
+        ]
+    )
+
+    expected = np.array([1.5, 3.5])
+    actual = utils.nanmean_f(posterior_array, axis=1)
+    np.testing.assert_array_equal(expected, actual)

--- a/treeple/stats/utils.py
+++ b/treeple/stats/utils.py
@@ -1,9 +1,10 @@
+import importlib.util
 import os
-import sys
 import warnings
 from typing import Optional, Tuple
 
 import numpy as np
+import scipy.sparse as sp
 from joblib import Parallel, delayed
 from numpy.typing import ArrayLike
 from scipy.stats import entropy
@@ -20,11 +21,15 @@ from sklearn.utils.validation import check_is_fitted
 from treeple._lib.sklearn.ensemble._forest import BaseForest
 
 BOTTLENECK_AVAILABLE = False
-if "bottleneck" in sys.modules:
+if importlib.util.find_spec("bottleneck"):
     import bottleneck as bn
 
     BOTTLENECK_AVAILABLE = True
 
+
+BOTTLENECK_WARNING = (
+    "Not using bottleneck for calculations involvings nans. Expect slower performance."
+)
 DISABLE_BN_ENV_VAR = "TREEPLE_NO_BOTTLENECK"
 
 if BOTTLENECK_AVAILABLE and DISABLE_BN_ENV_VAR not in os.environ:
@@ -201,6 +206,9 @@ def _compute_null_distribution_coleman(
     metric_star_pi : ArrayLike of shape (n_samples,)
         An array of the metrics computed on the other half of the trees.
     """
+    if not BOTTLENECK_AVAILABLE:
+        warnings.warn(BOTTLENECK_WARNING)
+
     # sample two sets of equal number of trees from the combined forest these are the posteriors
     # (n_estimators * 2, n_samples, n_outputs)
     all_y_pred = np.concatenate((y_pred_proba_normal, y_pred_proba_perm), axis=0)
@@ -316,3 +324,194 @@ def get_per_tree_oob_samples(est: BaseForest):
         )
         oob_samples.append(unsampled_indices)
     return oob_samples
+
+
+def _get_forest_preds_sparse(
+    all_y_pred: sp.csc_matrix,  # (n_trees, n_samples)
+    all_y_indicator: sp.csc_matrix,  # (n_trees, n_samples)
+    forest_indices: ArrayLike,  # (n_trees,)
+) -> ArrayLike:
+    """Get the forest predictions for a set of trees using sparse matrices."""
+    forest_indicator = np.zeros(len(forest_indices) * 2, dtype=np.uint8)
+    forest_indicator[forest_indices] = 1
+
+    forest_predictions = forest_indicator @ all_y_pred  # (n_samples)
+    forest_counts = forest_indicator @ all_y_indicator  # (n_samples)
+
+    return np.where(forest_counts, forest_predictions / forest_counts, np.nan)  # (n_samples)
+
+
+def _parallel_build_null_forests_sparse(
+    index_arr: ArrayLike,
+    all_y_pred: ArrayLike,
+    all_y_indicator: ArrayLike,
+    y_test: ArrayLike,
+    n_outputs: int,
+    seed: Optional[int],
+    shuffle: bool,
+    metric: str,
+    **metric_kwargs: dict,
+) -> tuple[float, float]:
+    """Randomly sample two sets of forests and compute the metric on each using sparse matrices."""
+    metric_func = METRIC_FUNCTIONS[metric]
+
+    if shuffle:
+        rng = np.random.default_rng(seed)
+        rng.shuffle(index_arr)
+
+    first_forest_inds = index_arr[: len(index_arr) // 2]
+    second_forest_inds = index_arr[len(index_arr) // 2 :]
+
+    y_pred_first_half = _get_forest_preds_sparse(
+        all_y_pred,
+        all_y_indicator,
+        first_forest_inds,
+    )
+    y_pred_second_half = _get_forest_preds_sparse(
+        all_y_pred,
+        all_y_indicator,
+        second_forest_inds,
+    )
+
+    first_pred_mask = np.isfinite(y_pred_first_half)
+    second_pred_mask = np.isfinite(y_pred_second_half)
+
+    # if this is binary classification, we add the second class
+    if n_outputs > 1:
+        y_pred_first_half = np.column_stack([y_pred_first_half, 1 - y_pred_first_half])
+        y_pred_second_half = np.column_stack([y_pred_second_half, 1 - y_pred_second_half])
+
+    first_half_metric = metric_func(
+        y_test[first_pred_mask],
+        y_pred_first_half[first_pred_mask],
+        **metric_kwargs,
+    )
+    second_half_metric = metric_func(
+        y_test[second_pred_mask],
+        y_pred_second_half[second_pred_mask],
+        **metric_kwargs,
+    )
+
+    return first_half_metric, second_half_metric
+
+
+def _compute_null_distribution_coleman_sparse(
+    y_test: ArrayLike,  # (n_samples, n_outputs)
+    y_pred_proba_normal: Tuple[ArrayLike, ArrayLike],  # n_trees, n_oob_samples_tree, n_outputs
+    y_pred_proba_perm: Tuple[ArrayLike, ArrayLike],  # n_trees, n_oob_samples_tree, n_outputs
+    metric: str = "mse",
+    n_repeats: int = 1000,
+    seed: Optional[int] = None,
+    n_jobs: Optional[int] = None,
+    **metric_kwargs,
+) -> Tuple[ArrayLike, float, float, ArrayLike, ArrayLike]:
+    """Compute null distribution using Coleman method.
+
+    The null distribution is comprised of two forests.
+
+    Parameters
+    ----------
+    y_test : ArrayLike of shape (n_samples, n_outputs)
+        The output matrix.
+    y_pred_proba_normal : Tuple of (ArrayLike, ArrayLike)
+        The predicted posteriors from the normal forest. The first element is a
+        list of out-of-bag indices for each tree. The second element is a list of
+        the predicted posteriors for each tree.
+    y_pred_proba_perm : Tuple of (ArrayLike, ArrayLike)
+        The predicted posteriors from the permuted forest. The first element is a
+        list of out-of-bag indices for each tree. The second element is a list of
+        the predicted posteriors for each tree.
+    metric : str, optional
+        The metric, which to compute the null distribution of statistics, by default 'mse'.
+    n_repeats : int, optional
+        The number of times to sample the null, by default 1000.
+    seed : int, optional
+        Random seed, by default None.
+    n_jobs : int, optional
+        The number of parallel jobs to run, by default None.
+    metric_kwargs : dict, optional
+        Keyword arguments to pass to the metric function.
+
+    Returns
+    -------
+    oob_predictions : ArrayLike of shape (n_trees, n_samples)
+        The out-of-bag predictions. The first n_trees/2 are from the normal forest
+        and the second n_trees/2 are from the permuted forest.
+    observe_stat : float
+        The observed statistic.
+    permute_stat : float
+        The permuted statistic.
+    metric_star : ArrayLike of shape (n_samples,)
+        An array of the metrics computed on half the trees.
+    metric_star_pi : ArrayLike of shape (n_samples,)
+        An array of the metrics computed on the other half of the trees.
+    """
+    n_trees = len(y_pred_proba_normal[0]) + len(y_pred_proba_perm[0])
+    n_outputs = y_pred_proba_normal[1][0].shape[1]
+
+    all_oob_idxs = y_pred_proba_normal[0] + y_pred_proba_perm[0]
+    tree_row_ids = np.repeat(
+        np.arange(n_trees, dtype=np.int32),
+        [len(oob) for oob in all_oob_idxs],
+    )  # (n_oob_samples)
+    all_oob_idxs = np.concatenate(all_oob_idxs, axis=0)  # (n_oob_samples)
+
+    # Because we are assuming 2D sparse matrices for binary classification or
+    # regression, we can assume that the number of outputs is 1. This is necessary
+    # to use scipy's sparse matrix format. However pydata has a general sparse
+    # matrix format that can be used for multi-output problems, but currently uses
+    # more memory.
+    all_oob_values = np.concatenate(
+        y_pred_proba_normal[1] + y_pred_proba_perm[1],
+        axis=0,
+    )[
+        :, 0
+    ]  # (n_oob_samples)
+
+    oob_predictions = sp.coo_matrix(
+        (all_oob_values, (tree_row_ids, all_oob_idxs)),
+        shape=(n_trees, len(y_test)),
+    ).tocsc()  # (n_trees, n_samples)
+
+    oob_indicators = sp.coo_matrix(
+        (np.ones_like(all_oob_values, dtype=np.uint8), (tree_row_ids, all_oob_idxs)),
+        shape=(n_trees, len(y_test)),
+    ).tocsc()  # (n_trees, n_samples)
+
+    observe_stat, permute_stat = _parallel_build_null_forests_sparse(
+        np.arange(n_trees),
+        oob_predictions,
+        oob_indicators,
+        y_test,
+        n_outputs,
+        seed,
+        False,
+        metric,
+        **metric_kwargs,
+    )
+
+    # generate the random seeds for the parallel jobs
+    ss = np.random.SeedSequence(seed)
+    out = Parallel(n_jobs=n_jobs)(
+        delayed(_parallel_build_null_forests_sparse)(
+            np.arange(n_trees),
+            oob_predictions,
+            oob_indicators,
+            y_test,
+            n_outputs,
+            seed,
+            True,
+            metric,
+            **metric_kwargs,
+        )
+        for _, seed in zip(range(n_repeats), ss.spawn(n_repeats))
+    )
+
+    metric_star = np.zeros((n_repeats,))
+    metric_star_pi = np.zeros((n_repeats,))
+
+    for idx, (first_half_metric, second_half_metric) in enumerate(out):
+        metric_star[idx] = first_half_metric
+        metric_star_pi[idx] = second_half_metric
+
+    return oob_predictions, observe_stat, permute_stat, metric_star, metric_star_pi

--- a/treeple/stats/utils.py
+++ b/treeple/stats/utils.py
@@ -214,9 +214,6 @@ def _compute_null_distribution_coleman(
     metric_star_pi : ArrayLike of shape (n_samples,)
         An array of the metrics computed on the other half of the trees.
     """
-    if not BOTTLENECK_AVAILABLE:
-        warnings.warn(BOTTLENECK_WARNING)
-
     # sample two sets of equal number of trees from the combined forest these are the posteriors
     # (n_estimators * 2, n_samples, n_outputs)
     all_y_pred = np.concatenate((y_pred_proba_normal, y_pred_proba_perm), axis=0)
@@ -337,9 +334,24 @@ def get_per_tree_oob_samples(est: BaseForest):
 def _get_forest_preds_sparse(
     all_y_pred: sp.csc_matrix,  # (n_trees, n_samples)
     all_y_indicator: sp.csc_matrix,  # (n_trees, n_samples)
-    forest_indices: ArrayLike,  # (n_trees,)
+    forest_indices: ArrayLike,  # (n_trees/2,)
 ) -> ArrayLike:
-    """Get the forest predictions for a set of trees using sparse matrices."""
+    """Get the forest predictions for a set of trees using sparse matrices.
+
+    Parameters
+    ----------
+    all_y_pred : sp.csc_matrix of shape (n_trees, n_samples)
+        The predicted posteriors from the forest.
+    all_y_indicator : sp.csc_matrix of shape (n_trees, n_samples)
+        The indicator matrix for the predictions.
+    forest_indices : ArrayLike of shape (n_trees/2,)
+        The indices of the trees in the forest that we are evaluating.
+
+    Returns
+    -------
+    ArrayLike of shape (n_samples,)
+        The averaged predictions for the forest.
+    """
     forest_indicator = np.zeros(len(forest_indices) * 2, dtype=np.uint8)
     forest_indicator[forest_indices] = 1
 

--- a/treeple/stats/utils.py
+++ b/treeple/stats/utils.py
@@ -464,7 +464,7 @@ def _compute_null_distribution_coleman_sparse(
     )  # (n_oob_samples)
     all_oob_idxs = np.concatenate(all_oob_idxs, axis=0)  # (n_oob_samples)
 
-    # Because we are assuming 2D sparse matrices for binary classification or
+    # XXX: Because we are assuming 2D sparse matrices for binary classification or
     # regression, we can assume that the number of outputs is 1. This is necessary
     # to use scipy's sparse matrix format. However pydata has a general sparse
     # matrix format that can be used for multi-output problems, but currently uses

--- a/treeple/stats/utils.py
+++ b/treeple/stats/utils.py
@@ -476,15 +476,15 @@ def _compute_null_distribution_coleman_sparse(
         :, 0
     ]  # (n_oob_samples)
 
-    oob_predictions = sp.coo_matrix(
+    oob_predictions = sp.csc_matrix(
         (all_oob_values, (tree_row_ids, all_oob_idxs)),
         shape=(n_trees, len(y_test)),
-    ).tocsc()  # (n_trees, n_samples)
+    )  # (n_trees, n_samples)
 
-    oob_indicators = sp.coo_matrix(
+    oob_indicators = sp.csc_matrix(
         (np.ones_like(all_oob_values, dtype=np.uint8), (tree_row_ids, all_oob_idxs)),
         shape=(n_trees, len(y_test)),
-    ).tocsc()  # (n_trees, n_samples)
+    )  # (n_trees, n_samples)
 
     observe_stat, permute_stat = _parallel_build_null_forests_sparse(
         np.arange(n_trees),

--- a/treeple/stats/utils.py
+++ b/treeple/stats/utils.py
@@ -33,14 +33,22 @@ BOTTLENECK_WARNING = (
 DISABLE_BN_ENV_VAR = "TREEPLE_NO_BOTTLENECK"
 
 if BOTTLENECK_AVAILABLE and DISABLE_BN_ENV_VAR not in os.environ:
-    nanmean_f = bn.nanmean
-    anynan_f = lambda arr: bn.anynan(arr, axis=2)
+
+    def nanmean_f(arr: ArrayLike, axis=None) -> ArrayLike:
+        return bn.nanmean(arr, axis=axis)
+
+    def anynan_f(arr: ArrayLike) -> ArrayLike:
+        return bn.anynan(arr, axis=2)
+
 else:
-    warnings.warn(
-        "Not using bottleneck for calculations involvings nans. Expect slower performance."
-    )
-    nanmean_f = np.nanmean
-    anynan_f = lambda arr: np.isnan(arr).any(axis=2)
+
+    def nanmean_f(arr: ArrayLike, axis=None) -> ArrayLike:
+        warnings.warn(BOTTLENECK_WARNING)
+        return np.nanmean(arr, axis=axis)
+
+    def anynan_f(arr: ArrayLike) -> ArrayLike:
+        warnings.warn(BOTTLENECK_WARNING)
+        return np.isnan(arr).any(axis=2)
 
 
 def _mutual_information(y_true: ArrayLike, y_pred_proba: ArrayLike) -> float:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines from scikit-learn: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #310 

#### What does this implement/fix? Explain your changes.

This adds a sparse implementation of `build_coleman_forest` to `treeple.stats`. The sparse implementation relies on `scipy.stats.sparse` and so only works in the case of binary classification and regression. In my tests using `cProfile`/`memray`, the sparse implementation is a little over 50% faster and uses about %7 less memory, see [pdf](https://github.com/user-attachments/files/16681054/sparse_profiling.pdf) for more information. I am also attaching the [profiling data](https://github.com/user-attachments/files/16681063/sparse_profiling.zip)
 if you'd like to take a look.

This PR also includres a change to the bottleneck implementation to for the dense implementation of `build_coleman_forest`. Specifically there are two important changes:
1. The check for the existence of the bottleneck package is now done using `importlib.util.find_spec("bottleneck")`. The old check using `sys` seemed to work fine and passed tests, but actually didn't seem work unless bottleneck had been imported before, which when the tests are run is true, but may not be the case in other situations
2. the aliased and lambda functions `nanmean_f` and `anynan_f` are now defined using `def` so that the warning message can moved into their respective calls rather than at import.

#### Any other comments?

The scipy.stats sparse implementation should be swapped out for pydata.sparse when that implementation is performant enough, as it is more general.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are.

See https://github.com/neurodata/treeple/blob/main/CONTRIBUTING.md for more
information on contributing.

Thanks for contributing!
-->
